### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Ein einfacher VDI-Client für Proxmox, entwickelt für Anwender, um bequem auf v
     * Die VMs werden mit dem Logo des OS angezeigt.
     * Im Icon ist ein Punkt zusehen, dieser zeigt ob die VM läuft
     * Durch Doppelklick kannst du nun die Verbindung zu deiner VM starten
-    * Das System wählt automatisch den Verbindungstype SPICE, VNC oder SSH
+    * Das System wählt automatisch den Verbindungstyp SPICE, VNC oder SSH
    
 ## Hinweis
 


### PR DESCRIPTION
## Summary
- fix German typo in README

## Testing
- `python -m py_compile $(find proxVDI -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68402672ce2883209c4881f31721177e