### PR TITLE
Fix Proxmox API call in worker

### DIFF
--- a/proxVDI/controller/workers.py
+++ b/proxVDI/controller/workers.py
@@ -70,7 +70,7 @@ class Worker(QObject):
 
     def _get_vm_config_and_osinfo(self, vm_data):
         try:
-            config = self.proxmox.nodes(vm_data['node']).qemu(vm_data['vmid']).config().get()
+            config = self.proxmox.nodes(vm_data['node']).qemu(vm_data['vmid']).config.get()
         except Exception as e:
             logger.error(f"Error retrieving VM config for VMID {vm_data['vmid']}: {e}")
             config = {}


### PR DESCRIPTION
## Summary
- fix Proxmox API usage for reading VM config

## Testing
- `python -m py_compile proxVDI/controller/workers.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840255dc984832085fda5da75ea47f5